### PR TITLE
Added support for theme config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can configure some options in `element-theme` by putting it in package.json:
     "browsers": ["ie > 9", "last 2 versions"],
     "out": "./theme",
     "config": "./element-variables.css",
+    "theme": "element-theme-default",
     "minimize": false
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,6 +10,7 @@ var config = Object.assign({
   browsers: ['ie > 9', 'last 2 versions'],
   out: './theme',
   config: './element-variables.css',
+  theme: 'element-theme-default',
   minimize: false
 }, pkg['element-theme'])
 
@@ -26,7 +27,7 @@ exports.features = {
     }
   }
 }
-exports.themePath = path.resolve(process.cwd(), './node_modules/element-theme-default')
+exports.themePath = path.resolve(process.cwd(), './node_modules/' + config.theme)
 exports.out = config.out
 exports.config = config.config
 exports.minimize = config.minimize


### PR DESCRIPTION
This PR adds a config for enabling other ElementUI themes to be used. (e.g: https://github.com/rodrigoddalmeida/elementui-material-icons-theme)