### PR TITLE
修复当用户自己项目中定义了主题时，错误提示不正确的问题

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -33,3 +33,4 @@ exports.config = config.config
 exports.minimize = config.minimize
 exports.browsers = config.browsers
 exports.components = config.components
+exports.themeName = config.theme

--- a/lib/gen-vars.js
+++ b/lib/gen-vars.js
@@ -10,7 +10,7 @@ var filePath = path.resolve(process.cwd(), config.config)
 
 exports.check = function () {
   if (!fs.existsSync(varsPath)) {
-    ora('please install `element-theme-default`').fail()
+    ora('please install `' + config.themeName + '`').fail()
     process.exit(1)
   }
 }


### PR DESCRIPTION
最近在自定义主题的时候，发现的一个问题
`{
  "element-theme": {
    "theme": "foo-bar",
  }
}`
当时我在自己的项目的 package.json 加入了如上设置，然后忘记把这个theme 安装到自己的项目中时，直接运行 et 命令，et命令报错是这样的
`please install element-theme-default`
我一开始以为 element-theme-default 是必须依赖，所以又把element-theme-default 装了一遍，发现依然报同样的错误。于是只好读了一下 et 工具的代码，发现原来是错误信息提示不正确，其实是我自己忘记把自己修改后的 theme 装到新项目里了。
于是便有了这个 PR。