### PR TITLE
Support browserslist configure and don't repeat declare twice.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,13 +6,13 @@ try {
   pkg = require(path.resolve(process.cwd(), 'package.json'))
 } catch (err) {}
 
+var browsers = ['ie > 9', 'last 2 versions'];
 var config = Object.assign({
-  browsers: ['ie > 9', 'last 2 versions'],
   out: './theme',
   config: './element-variables.scss',
   theme: 'element-theme-chalk',
   minimize: false
-}, pkg['element-theme'])
+}, {browsers: pkg['browserslist'] || browsers}, pkg['element-theme']);
 
 exports.themePath = path.resolve(process.cwd(), './node_modules/' + config.theme)
 exports.out = config.out


### PR DESCRIPTION
When we use the browserlist in the package.json, we need to declare twice about the browsers. it's very deplicate.